### PR TITLE
リリース

### DIFF
--- a/backend/prisma/seeds/development.ts
+++ b/backend/prisma/seeds/development.ts
@@ -15,6 +15,7 @@ export const executeDevelopment = async () => {
         create: {
           email: 'admin@example.com',
           name: 'admin',
+          discord_user_id: '',
           password_digest:
             '$2b$08$nOByk5csZtvw62zGlLZLne63t/jDGqGEoofMWyZ8egaNkcdC1HDra', // password
           role_id: admin.id,
@@ -27,6 +28,7 @@ export const executeDevelopment = async () => {
         create: {
           email: 'user@example.com',
           name: 'user',
+          discord_user_id: '',
           password_digest:
             '$2b$08$nOByk5csZtvw62zGlLZLne63t/jDGqGEoofMWyZ8egaNkcdC1HDra', // password
           role_id: user.id,

--- a/backend/prisma/seeds/test/internalUser.ts
+++ b/backend/prisma/seeds/test/internalUser.ts
@@ -14,6 +14,7 @@ export const seedInternalUser = async () => {
       email: 'test@example.com',
       role_id: admin.id,
       name: 'admin',
+      discord_user_id: '',
       password_digest:
         '$2b$08$nOByk5csZtvw62zGlLZLne63t/jDGqGEoofMWyZ8egaNkcdC1HDra', // password
     },

--- a/backend/server/graphql/internalApi/__generated__/internal_api_types.d.ts
+++ b/backend/server/graphql/internalApi/__generated__/internal_api_types.d.ts
@@ -180,6 +180,7 @@ export interface NexusGenObjects {
     reservable: string; // String!
   }
   InternalUser: { // root type
+    discord_user_id: string; // String!
     email: string; // String!
     id: NexusGenScalars['BigInt']; // BigInt!
     name: string; // String!
@@ -345,6 +346,7 @@ export interface NexusGenFieldTypes {
     reservable: string; // String!
   }
   InternalUser: { // field return type
+    discord_user_id: string; // String!
     email: string; // String!
     id: NexusGenScalars['BigInt']; // BigInt!
     name: string; // String!
@@ -564,6 +566,7 @@ export interface NexusGenFieldTypeNames {
     reservable: 'String'
   }
   InternalUser: { // field return type name
+    discord_user_id: 'String'
     email: 'String'
     id: 'BigInt'
     name: 'String'
@@ -726,6 +729,7 @@ export interface NexusGenArgTypes {
       url?: string | null; // String
     }
     createInternalUser: { // args
+      discord_user_id: string; // String!
       email: string; // String!
       name: string; // String!
       password: string; // String!
@@ -799,6 +803,7 @@ export interface NexusGenArgTypes {
       url: string; // String!
     }
     updateInternalUser: { // args
+      discord_user_id: string; // String!
       email: string; // String!
       id: NexusGenScalars['BigInt']; // BigInt!
       name: string; // String!

--- a/backend/server/graphql/internalApi/mutations/createInternalUser.ts
+++ b/backend/server/graphql/internalApi/mutations/createInternalUser.ts
@@ -9,6 +9,7 @@ export const createInternalUserField = mutationField((t) => {
     type: internalUserType,
     args: {
       name: nonNull(stringArg()),
+      discord_user_id: nonNull(stringArg()),
       email: nonNull(stringArg()),
       password: nonNull(stringArg()),
       roleId: nonNull(intArg()),
@@ -18,6 +19,7 @@ export const createInternalUserField = mutationField((t) => {
       try {
         return await ctx.prisma.internalUser.create({
           data: {
+            discord_user_id: args.discord_user_id,
             name: args.name,
             email: args.email,
             password_digest: hashedPassword,

--- a/backend/server/graphql/internalApi/mutations/createStockRequest.ts
+++ b/backend/server/graphql/internalApi/mutations/createStockRequest.ts
@@ -45,10 +45,11 @@ export const createStockRequestField = mutationField((t) => {
           },
           include: {
             productRegistrations: { include: { product: true } },
+            internalUser: true,
           },
         });
 
-        postStockRequestAlert(stockRequest, ctx.currentInternalUser!);
+        postStockRequestAlert(stockRequest);
 
         return stockRequest;
       } catch (e) {

--- a/backend/server/graphql/internalApi/mutations/rejectStockRequest.ts
+++ b/backend/server/graphql/internalApi/mutations/rejectStockRequest.ts
@@ -16,6 +16,7 @@ export const rejectStockRequestField = mutationField((t) => {
         where: { id: args.id },
         include: {
           productRegistrations: { include: { product: true } },
+          internalUser: true,
         },
       });
       try {

--- a/backend/server/graphql/internalApi/mutations/updateInternalUser.ts
+++ b/backend/server/graphql/internalApi/mutations/updateInternalUser.ts
@@ -12,6 +12,7 @@ export const updateInternalUserField = mutationField((t) => {
       name: nonNull(stringArg()),
       email: nonNull(stringArg()),
       password: nonNull(stringArg()),
+      discord_user_id: nonNull(stringArg()),
       roleId: nonNull(intArg()),
     },
     resolve: async (_, args, ctx) => {
@@ -22,6 +23,7 @@ export const updateInternalUserField = mutationField((t) => {
             name: args.name,
             email: args.email,
             password_digest: hashedPassword,
+            discord_user_id: args.discord_user_id,
             role_id: args.roleId,
           },
           where: {

--- a/backend/server/graphql/internalApi/queries/session.ts
+++ b/backend/server/graphql/internalApi/queries/session.ts
@@ -15,6 +15,7 @@ export const sessionField = queryField((t) => {
           id: ctx.currentInternalUser.id,
           name: ctx.currentInternalUser.name,
           email: ctx.currentInternalUser.email,
+          discord_user_id: ctx.currentInternalUser.discord_user_id,
         },
       };
     },

--- a/backend/server/graphql/internalApi/types/internalUserType.ts
+++ b/backend/server/graphql/internalApi/types/internalUserType.ts
@@ -8,6 +8,7 @@ export const internalUserType = objectType({
     t.field(InternalUser.id);
     t.field(InternalUser.name);
     t.field(InternalUser.email);
+    t.field(InternalUser.discord_user_id);
     t.nonNull.field(InternalUser.role);
   },
 });

--- a/backend/server/services/api/discordApi/index.ts
+++ b/backend/server/services/api/discordApi/index.ts
@@ -52,7 +52,7 @@ const postStockRequestAlert = (
   const lines = stockRequest.productRegistrations
     .map((productRegistration) => `\n・${productRegistration.product.name}`)
     .join();
-  const content = `${stockRequest.internalUser.name}さんが在庫リクエストをしたよ <:yeah:913316943921033247> \n https://ham-media-app.net/admin/stock_requests/${stockRequest.id}/edit ${lines}`;
+  const content = `<@${stockRequest.internalUser.discord_user_id}> さんが在庫リクエストをしたよ <:yeah:913316943921033247> \n https://ham-media-app.net/admin/stock_requests/${stockRequest.id}/edit ${lines}`;
   postStockAlert(content);
 };
 
@@ -70,7 +70,7 @@ const postStockRequestRejectionAlert = (
   const lines = stockRequest.productRegistrations
     .map((productRegistration) => `\n・${productRegistration.product.name}`)
     .join();
-  const content = `${stockRequest.internalUser.name}さんの在庫リクエストが${rejectInternalUser.name}さんに棄却されたよ <:jii:913298500861698058> ${lines} \n[棄却メッセージ]\n${message}`;
+  const content = `<@${stockRequest.internalUser.discord_user_id}> さんの在庫リクエストが <@${rejectInternalUser.discord_user_id}> さんに棄却されたよ <:jii:913298500861698058> ${lines} \n[棄却メッセージ]\n${message}`;
   postStockAlert(content);
 };
 
@@ -91,7 +91,7 @@ const postStockRequestApprovalAlert = (
         `\n・${productRegistration.product.name} https://ham-media-app.net/admin/products/${productRegistration.product.id}`
     )
     .join();
-  const content = `${stockRequest.internalUser.name}さんの在庫リクエストが${approvingInternalUser.name}さんに承認されたよ <:ok:776668642976071730> \n${approvingInternalUser.name}さんは在庫の割り当てをやってね🙊 ${lines} \n[承認メッセージ]\n${message}\n`;
+  const content = `<@${stockRequest.internalUser.discord_user_id}> さんの在庫リクエストが <@${approvingInternalUser.discord_user_id}> さんに承認されたよ <:ok:776668642976071730> \n <@${approvingInternalUser.discord_user_id}> さんは在庫の割り当てをやってね🙊 ${lines} \n[承認メッセージ]\n${message}\n`;
   postStockAlert(content);
 };
 

--- a/backend/server/services/api/discordApi/index.ts
+++ b/backend/server/services/api/discordApi/index.ts
@@ -42,34 +42,35 @@ const postStockExpiringAlert = (variables: PostStockAlertVariables): void => {
 
 const postStockRequestAlert = (
   stockRequest: StockRequest & {
+    internalUser: InternalUser;
     productRegistrations: (StockRequestProductRegistration & {
       product: Product;
     })[];
-  },
-  internalUser: InternalUser
+  }
 ): void => {
   if (!DISCORD_STOCK_WEBHOOK_URL) return;
   const lines = stockRequest.productRegistrations
     .map((productRegistration) => `\n・${productRegistration.product.name}`)
     .join();
-  const content = `${internalUser.name}さんが在庫リクエストをしたよ <:yeah:913316943921033247> \n https://ham-media-app.net/admin/stock_requests/${stockRequest.id}/edit ${lines}`;
+  const content = `${stockRequest.internalUser.name}さんが在庫リクエストをしたよ <:yeah:913316943921033247> \n https://ham-media-app.net/admin/stock_requests/${stockRequest.id}/edit ${lines}`;
   postStockAlert(content);
 };
 
 const postStockRequestRejectionAlert = (
   stockRequest: StockRequest & {
+    internalUser: InternalUser;
     productRegistrations: (StockRequestProductRegistration & {
       product: Product;
     })[];
   },
-  internalUser: InternalUser,
+  rejectInternalUser: InternalUser,
   message: string
 ) => {
   if (!DISCORD_STOCK_WEBHOOK_URL) return;
   const lines = stockRequest.productRegistrations
     .map((productRegistration) => `\n・${productRegistration.product.name}`)
     .join();
-  const content = `${internalUser.name}さんの以下の在庫リクエストが棄却されたよ <:jii:913298500861698058> ${lines} \n[棄却メッセージ]\n${message}`;
+  const content = `${stockRequest.internalUser.name}さんの在庫リクエストが${rejectInternalUser.name}さんに棄却されたよ <:jii:913298500861698058> ${lines} \n[棄却メッセージ]\n${message}`;
   postStockAlert(content);
 };
 
@@ -90,7 +91,7 @@ const postStockRequestApprovalAlert = (
         `\n・${productRegistration.product.name} https://ham-media-app.net/admin/products/${productRegistration.product.id}`
     )
     .join();
-  const content = `${stockRequest.internalUser.name}さんの以下の在庫リクエストが承認されたよ <:ok:776668642976071730> \n${approvingInternalUser.name}さんは在庫の割り当てをやってね🙊 ${lines} \n[承認メッセージ]\n${message}\n`;
+  const content = `${stockRequest.internalUser.name}さんの在庫リクエストが${approvingInternalUser.name}さんに承認されたよ <:ok:776668642976071730> \n${approvingInternalUser.name}さんは在庫の割り当てをやってね🙊 ${lines} \n[承認メッセージ]\n${message}\n`;
   postStockAlert(content);
 };
 

--- a/backend/tests/integrations/graphql/internalApi/mutations/approveStockRequest.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/mutations/approveStockRequest.spec.ts
@@ -29,6 +29,7 @@ describe('approveStockRequest', () => {
     const role = await db.role.create({ data: { name: ROLE_NAME } });
     const internalUser = await db.internalUser.create({
       data: {
+        discord_user_id: '',
         name: INTERNAL_USER_NAME,
         email: INTERNAL_USER_EMAIL,
         password_digest: 'test',

--- a/backend/tests/integrations/graphql/internalApi/mutations/deleteStockRequest.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/mutations/deleteStockRequest.spec.ts
@@ -23,6 +23,7 @@ describe('deleteStockRequest', () => {
     const role = await db.role.create({ data: { name: ROLE_NAME } });
     const internalUser = await db.internalUser.create({
       data: {
+        discord_user_id: '',
         name: INTERNAL_USER_NAME,
         email: INTERNAL_USER_EMAIL,
         password_digest: 'test',

--- a/backend/tests/integrations/graphql/internalApi/mutations/rejectStockRequest.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/mutations/rejectStockRequest.spec.ts
@@ -29,6 +29,7 @@ describe('rejectStockRequest', () => {
     const role = await db.role.create({ data: { name: ROLE_NAME } });
     const internalUser = await db.internalUser.create({
       data: {
+        discord_user_id: '',
         name: INTERNAL_USER_NAME,
         email: INTERNAL_USER_EMAIL,
         password_digest: 'test',

--- a/backend/tests/integrations/graphql/internalApi/queries/stockRequest.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/queries/stockRequest.spec.ts
@@ -32,6 +32,7 @@ const init = async () => {
   const role = await db.role.create({ data: { name: ROLE_NAME } });
   const internalUser = await db.internalUser.create({
     data: {
+      discord_user_id: '',
       name: INTERNAL_USER_NAME,
       email: INTERNAL_USER_EMAIL,
       password_digest: 'test',

--- a/backend/tests/integrations/graphql/internalApi/queries/stockRequestConnection.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/queries/stockRequestConnection.spec.ts
@@ -61,6 +61,7 @@ const init = async () => {
 
   const internalUser1 = await db.internalUser.create({
     data: {
+      discord_user_id: '',
       id: INTERNAL_USER_ID_1,
       name: INTERNAL_USER_NAME_1,
       email: INTERNAL_USER_EMAIL_1,
@@ -70,6 +71,7 @@ const init = async () => {
   });
   const internalUser2 = await db.internalUser.create({
     data: {
+      discord_user_id: '',
       id: INTERNAL_USER_ID_2,
       name: INTERNAL_USER_NAME_2,
       email: INTERNAL_USER_EMAIL_2,

--- a/backend/tests/integrations/graphql/internalApi/queries/stocks.spec.ts
+++ b/backend/tests/integrations/graphql/internalApi/queries/stocks.spec.ts
@@ -41,6 +41,7 @@ const init = async () => {
     data: {
       name: STOCK_ADMIN_INTERNAL_USER_NAME,
       email: STOCK_ADMIN_INTERNAL_USER_EMAIL,
+      discord_user_id: '',
       password_digest: 'test',
       role_id: role.id,
     },
@@ -49,6 +50,7 @@ const init = async () => {
     data: {
       name: STOCK_ASSIGNED_INTERNAL_USER_NAME,
       email: STOCK_ASSIGNED_INTERNAL_USER_EMAIL,
+      discord_user_id: '',
       password_digest: 'test',
       role_id: role.id,
     },

--- a/backend/tests/integrations/graphql/publicApi/mutations/createSession.spec.ts
+++ b/backend/tests/integrations/graphql/publicApi/mutations/createSession.spec.ts
@@ -24,6 +24,7 @@ const setupData = async () => {
   const hashedPassword = await hash(INTERNAL_USER_PASSWORD, 8);
   await db.internalUser.create({
     data: {
+      discord_user_id: '',
       name: INTERNAL_USER_NAME,
       email: INTERNAL_USER_EMAIL,
       password_digest: hashedPassword,

--- a/frontend/api/internal_api/createInternalUser.ts
+++ b/frontend/api/internal_api/createInternalUser.ts
@@ -7,12 +7,14 @@ export const createInternalUser = gql`
     $name: String!
     $email: String!
     $password: String!
+    $discord_user_id: String!
     $roleId: Int!
   ) {
     createInternalUser(
       name: $name
       email: $email
       password: $password
+      discord_user_id: $discord_user_id
       roleId: $roleId
     ) {
       ...InternalUserFields

--- a/frontend/api/internal_api/fragments/internalUser.ts
+++ b/frontend/api/internal_api/fragments/internalUser.ts
@@ -7,6 +7,7 @@ export const INTERNAL_USER_FIELDS = gql`
     id
     email
     name
+    discord_user_id
     role {
       ...RoleFields
     }

--- a/frontend/api/internal_api/types.ts
+++ b/frontend/api/internal_api/types.ts
@@ -191,6 +191,7 @@ export type HospitalReservationStatusInputType = {
 /** A internal user */
 export type InternalUser = {
   __typename?: 'InternalUser';
+  discord_user_id: Scalars['String'];
   email: Scalars['String'];
   id: Scalars['BigInt'];
   name: Scalars['String'];
@@ -257,6 +258,7 @@ export type MutationCreateHospitalArgs = {
 
 
 export type MutationCreateInternalUserArgs = {
+  discord_user_id: Scalars['String'];
   email: Scalars['String'];
   name: Scalars['String'];
   password: Scalars['String'];
@@ -364,6 +366,7 @@ export type MutationUpdateHospitalArgs = {
 
 
 export type MutationUpdateInternalUserArgs = {
+  discord_user_id: Scalars['String'];
   email: Scalars['String'];
   id: Scalars['BigInt'];
   name: Scalars['String'];
@@ -667,7 +670,7 @@ export type InternalAllocateStockMutationVariables = Exact<{
 }>;
 
 
-export type InternalAllocateStockMutation = { __typename?: 'Mutation', allocateStock: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
+export type InternalAllocateStockMutation = { __typename?: 'Mutation', allocateStock: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
 
 export type InternalApproveStockRequestMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -691,11 +694,12 @@ export type InternalCreateInternalUserMutationVariables = Exact<{
   name: Scalars['String'];
   email: Scalars['String'];
   password: Scalars['String'];
+  discord_user_id: Scalars['String'];
   roleId: Scalars['Int'];
 }>;
 
 
-export type InternalCreateInternalUserMutation = { __typename?: 'Mutation', createInternalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } };
+export type InternalCreateInternalUserMutation = { __typename?: 'Mutation', createInternalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } };
 
 export type InternalCreateMakerMutationVariables = Exact<{
   name: Scalars['String'];
@@ -713,7 +717,7 @@ export type InternalCreateProductMutationVariables = Exact<{
 }>;
 
 
-export type InternalCreateProductMutation = { __typename?: 'Mutation', createProduct: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
+export type InternalCreateProductMutation = { __typename?: 'Mutation', createProduct: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
 
 export type InternalCreateProductTagGroupMutationVariables = Exact<{
   name: Scalars['String'];
@@ -743,7 +747,7 @@ export type InternalCreateStockRequestMutationVariables = Exact<{
 }>;
 
 
-export type InternalCreateStockRequestMutation = { __typename?: 'Mutation', createStockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
+export type InternalCreateStockRequestMutation = { __typename?: 'Mutation', createStockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
 
 export type InternalCreateStocksMutationVariables = Exact<{
   productId: Scalars['Int'];
@@ -751,7 +755,7 @@ export type InternalCreateStocksMutationVariables = Exact<{
 }>;
 
 
-export type InternalCreateStocksMutation = { __typename?: 'Mutation', createStocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
+export type InternalCreateStocksMutation = { __typename?: 'Mutation', createStocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
 
 export type InternalDeleteInternalUserMutationVariables = Exact<{
   id: Scalars['BigInt'];
@@ -797,13 +801,13 @@ export type InternalDeleteStockRequestMutation = { __typename?: 'Mutation', dele
 
 export type HospitalFieldsFragment = { __typename?: 'Hospital', id: BigInt, name: string, url: string, deleted: boolean, internal_memo: string, hospitalAddress?: { __typename?: 'HospitalAddress', id: BigInt, address: string, phone_number: string, prefecture: { __typename?: 'Prefecture', name: string, id: BigInt } } | null | undefined, hospitalBusinessForm?: { __typename?: 'HospitalBusinessForm', id: BigInt, business_hour: string, closed_day: string, insurance_enabled: string, remark: string } | null | undefined, hospitalCertificationOption?: { __typename?: 'HospitalCertificationOption', id: BigInt, nichiju_registered: string, jsava_registered: string } | null | undefined, hospitalInternalReputation?: { __typename?: 'HospitalInternalReputation', id: BigInt, star: number, remark: string } | null | undefined, hospitalNightServiceOption?: { __typename?: 'HospitalNightServiceOption', id: BigInt, status: string, remark: string } | null | undefined, hospitalNightUrgentActionOption?: { __typename?: 'HospitalNightUrgentActionOption', id: BigInt, status: string } | null | undefined, hospitalReservationStatus?: { __typename?: 'HospitalReservationStatus', id: BigInt, required: string, reservable: string, remark: string } | null | undefined };
 
-export type InternalUserFieldsFragment = { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } };
+export type InternalUserFieldsFragment = { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } };
 
 export type MakerFieldsFragment = { __typename?: 'Maker', id: number, name: string };
 
-export type ProductFieldsFragment = { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
+export type ProductFieldsFragment = { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
 
-export type StockFieldsFragment = { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined };
+export type StockFieldsFragment = { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined };
 
 export type ProductTaggingFieldsFragment = { __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } };
 
@@ -813,7 +817,7 @@ export type ProductTagGroupFieldsFragment = { __typename?: 'ProductTagGroup', id
 
 export type RoleFieldsFragment = { __typename?: 'Role', id: number, name: string };
 
-export type StockRequestFieldsFragment = { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> };
+export type StockRequestFieldsFragment = { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> };
 
 export type InternalGetHospitalQueryVariables = Exact<{
   id: Scalars['BigInt'];
@@ -843,12 +847,12 @@ export type InternalGetInternalUserQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetInternalUserQuery = { __typename?: 'Query', internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } };
+export type InternalGetInternalUserQuery = { __typename?: 'Query', internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } };
 
 export type InternalGetInternalUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type InternalGetInternalUsersQuery = { __typename?: 'Query', internalUsers: Array<{ __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }> };
+export type InternalGetInternalUsersQuery = { __typename?: 'Query', internalUsers: Array<{ __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }> };
 
 export type InternalGetMakerQueryVariables = Exact<{
   id: Scalars['Int'];
@@ -867,7 +871,7 @@ export type InternalGetProductQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetProductQuery = { __typename?: 'Query', product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
+export type InternalGetProductQuery = { __typename?: 'Query', product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
 
 export type LocalGetProductCartItemsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -885,7 +889,7 @@ export type InternalGetProductConnectionQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetProductConnectionQuery = { __typename?: 'Query', productConnection?: { __typename?: 'ProductConnection', edges?: Array<{ __typename?: 'ProductEdge', node?: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } | null | undefined } | null | undefined> | null | undefined, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null | undefined, endCursor?: string | null | undefined } } | null | undefined };
+export type InternalGetProductConnectionQuery = { __typename?: 'Query', productConnection?: { __typename?: 'ProductConnection', edges?: Array<{ __typename?: 'ProductEdge', node?: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } | null | undefined } | null | undefined> | null | undefined, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null | undefined, endCursor?: string | null | undefined } } | null | undefined };
 
 export type InternalGetProductIdsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -914,7 +918,7 @@ export type InternalGetProductsQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetProductsQuery = { __typename?: 'Query', products: Array<{ __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> }> };
+export type InternalGetProductsQuery = { __typename?: 'Query', products: Array<{ __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> }> };
 
 export type InternalGetRolesQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -931,7 +935,7 @@ export type InternalGetStockRequestQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetStockRequestQuery = { __typename?: 'Query', stockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
+export type InternalGetStockRequestQuery = { __typename?: 'Query', stockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
 
 export type InternalGetStockRequestConnectionQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']>;
@@ -940,14 +944,14 @@ export type InternalGetStockRequestConnectionQueryVariables = Exact<{
 }>;
 
 
-export type InternalGetStockRequestConnectionQuery = { __typename?: 'Query', stockRequestConnection?: { __typename?: 'StockRequestConnection', edges?: Array<{ __typename?: 'StockRequestEdge', node?: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } | null | undefined } | null | undefined> | null | undefined, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null | undefined, endCursor?: string | null | undefined } } | null | undefined };
+export type InternalGetStockRequestConnectionQuery = { __typename?: 'Query', stockRequestConnection?: { __typename?: 'StockRequestConnection', edges?: Array<{ __typename?: 'StockRequestEdge', node?: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } | null | undefined } | null | undefined> | null | undefined, pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null | undefined, endCursor?: string | null | undefined } } | null | undefined };
 
 export type InternalGetStocksQueryVariables = Exact<{
   productId: Scalars['Int'];
 }>;
 
 
-export type InternalGetStocksQuery = { __typename?: 'Query', stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
+export type InternalGetStocksQuery = { __typename?: 'Query', stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> };
 
 export type LocalReadIsAdminQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -967,7 +971,7 @@ export type InternalReturnStockMutationVariables = Exact<{
 }>;
 
 
-export type InternalReturnStockMutation = { __typename?: 'Mutation', returnStock: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
+export type InternalReturnStockMutation = { __typename?: 'Mutation', returnStock: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
 
 export type InternalUpdateHospitalMutationVariables = Exact<{
   id: Scalars['BigInt'];
@@ -992,11 +996,12 @@ export type InternalUpdateInternalUserMutationVariables = Exact<{
   name: Scalars['String'];
   email: Scalars['String'];
   password: Scalars['String'];
+  discord_user_id: Scalars['String'];
   roleId: Scalars['Int'];
 }>;
 
 
-export type InternalUpdateInternalUserMutation = { __typename?: 'Mutation', updateInternalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } };
+export type InternalUpdateInternalUserMutation = { __typename?: 'Mutation', updateInternalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } };
 
 export type InternalUpdateMakerMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -1015,7 +1020,7 @@ export type InternalUpdateProductMutationVariables = Exact<{
 }>;
 
 
-export type InternalUpdateProductMutation = { __typename?: 'Mutation', updateProduct: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
+export type InternalUpdateProductMutation = { __typename?: 'Mutation', updateProduct: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } };
 
 export type InternalUpdateProductTagMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -1039,7 +1044,7 @@ export type InternalUpdateStockInternalUserMutationVariables = Exact<{
 }>;
 
 
-export type InternalUpdateStockInternalUserMutation = { __typename?: 'Mutation', updateStockInternalUser: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
+export type InternalUpdateStockInternalUserMutation = { __typename?: 'Mutation', updateStockInternalUser: { __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined } };
 
 export type InternalUpdateStockRequestMutationVariables = Exact<{
   id: Scalars['Int'];
@@ -1047,7 +1052,7 @@ export type InternalUpdateStockRequestMutationVariables = Exact<{
 }>;
 
 
-export type InternalUpdateStockRequestMutation = { __typename?: 'Mutation', updateStockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
+export type InternalUpdateStockRequestMutation = { __typename?: 'Mutation', updateStockRequest: { __typename?: 'StockRequest', id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, productRegistrations: Array<{ __typename?: 'StockRequestProductRegistration', id: number, product: { __typename?: 'Product', id: number, name: string, remark: string, url: string, totalStockAmount: number, allocatedStockAmount: number, remainingStockAmount: number, productTaggings: Array<{ __typename?: 'ProductTagging', id: number, productTag: { __typename?: 'ProductTag', id: number, name: string } }>, maker: { __typename?: 'Maker', id: number, name: string }, stocks: Array<{ __typename?: 'Stock', id: number, expired_at: any, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } }, stockAllocation?: { __typename?: 'StockAllocation', created_at: any, id: number, internalUser: { __typename?: 'InternalUser', id: BigInt, email: string, name: string, discord_user_id: string, role: { __typename?: 'Role', id: number, name: string } } } | null | undefined }> } }> } };
 
 export const HospitalFieldsFragmentDoc = gql`
     fragment HospitalFields on Hospital {
@@ -1125,6 +1130,7 @@ export const InternalUserFieldsFragmentDoc = gql`
   id
   email
   name
+  discord_user_id
   role {
     ...RoleFields
   }
@@ -1307,11 +1313,12 @@ export type InternalCreateHospitalMutationHookResult = ReturnType<typeof useInte
 export type InternalCreateHospitalMutationResult = Apollo.MutationResult<InternalCreateHospitalMutation>;
 export type InternalCreateHospitalMutationOptions = Apollo.BaseMutationOptions<InternalCreateHospitalMutation, InternalCreateHospitalMutationVariables>;
 export const InternalCreateInternalUserDocument = gql`
-    mutation InternalCreateInternalUser($name: String!, $email: String!, $password: String!, $roleId: Int!) {
+    mutation InternalCreateInternalUser($name: String!, $email: String!, $password: String!, $discord_user_id: String!, $roleId: Int!) {
   createInternalUser(
     name: $name
     email: $email
     password: $password
+    discord_user_id: $discord_user_id
     roleId: $roleId
   ) {
     ...InternalUserFields
@@ -1336,6 +1343,7 @@ export type InternalCreateInternalUserMutationFn = Apollo.MutationFunction<Inter
  *      name: // value for 'name'
  *      email: // value for 'email'
  *      password: // value for 'password'
+ *      discord_user_id: // value for 'discord_user_id'
  *      roleId: // value for 'roleId'
  *   },
  * });
@@ -2708,12 +2716,13 @@ export type InternalUpdateHospitalMutationHookResult = ReturnType<typeof useInte
 export type InternalUpdateHospitalMutationResult = Apollo.MutationResult<InternalUpdateHospitalMutation>;
 export type InternalUpdateHospitalMutationOptions = Apollo.BaseMutationOptions<InternalUpdateHospitalMutation, InternalUpdateHospitalMutationVariables>;
 export const InternalUpdateInternalUserDocument = gql`
-    mutation InternalUpdateInternalUser($id: BigInt!, $name: String!, $email: String!, $password: String!, $roleId: Int!) {
+    mutation InternalUpdateInternalUser($id: BigInt!, $name: String!, $email: String!, $password: String!, $discord_user_id: String!, $roleId: Int!) {
   updateInternalUser(
     id: $id
     name: $name
     email: $email
     password: $password
+    discord_user_id: $discord_user_id
     roleId: $roleId
   ) {
     ...InternalUserFields
@@ -2739,6 +2748,7 @@ export type InternalUpdateInternalUserMutationFn = Apollo.MutationFunction<Inter
  *      name: // value for 'name'
  *      email: // value for 'email'
  *      password: // value for 'password'
+ *      discord_user_id: // value for 'discord_user_id'
  *      roleId: // value for 'roleId'
  *   },
  * });

--- a/frontend/api/internal_api/updateInternalUser.ts
+++ b/frontend/api/internal_api/updateInternalUser.ts
@@ -8,6 +8,7 @@ export const updateInternalUser = gql`
     $name: String!
     $email: String!
     $password: String!
+    $discord_user_id: String!
     $roleId: Int!
   ) {
     updateInternalUser(
@@ -15,6 +16,7 @@ export const updateInternalUser = gql`
       name: $name
       email: $email
       password: $password
+      discord_user_id: $discord_user_id
       roleId: $roleId
     ) {
       ...InternalUserFields

--- a/frontend/components/organisms/admin/internal_users/edit/Form.tsx
+++ b/frontend/components/organisms/admin/internal_users/edit/Form.tsx
@@ -6,6 +6,7 @@ import {
   FormControl,
   FormLabel,
   FormErrorMessage,
+  FormHelperText,
   Select,
 } from '@chakra-ui/react';
 import { useForm, Controller, SubmitHandler } from 'react-hook-form';
@@ -27,6 +28,7 @@ interface FormInput {
   name: string;
   email: string;
   password: string;
+  discordUserId: string;
   roleId: string;
 }
 
@@ -56,6 +58,7 @@ const Form: React.VFC<Props> = ({ internalUserId }) => {
     name,
     email,
     password,
+    discordUserId,
     roleId,
   }) => {
     if (internalUser) {
@@ -67,6 +70,7 @@ const Form: React.VFC<Props> = ({ internalUserId }) => {
             id: internalUser.id,
             name,
             email,
+            discord_user_id: discordUserId,
             password,
             roleId: Number(roleId),
           },
@@ -122,6 +126,34 @@ const Form: React.VFC<Props> = ({ internalUserId }) => {
                   />
                   {errors.email && (
                     <FormErrorMessage>{errors.email.message}</FormErrorMessage>
+                  )}
+                </FormControl>
+                <FormControl
+                  id="discordUserId"
+                  isRequired
+                  isInvalid={!!errors.discordUserId}
+                >
+                  <FormLabel>discord user id</FormLabel>
+                  <Controller
+                    name="discordUserId"
+                    defaultValue={internalUser.discord_user_id}
+                    control={control}
+                    rules={validators.discordUserId.rules}
+                    render={({ field }) => (
+                      <Input
+                        type="text"
+                        isInvalid={!!errors.discordUserId}
+                        {...field}
+                      />
+                    )}
+                  />
+                  <FormHelperText>
+                    通知のメンションに必要です。18桁の数字が有効です
+                  </FormHelperText>
+                  {errors.discordUserId && (
+                    <FormErrorMessage>
+                      {errors.discordUserId.message}
+                    </FormErrorMessage>
                   )}
                 </FormControl>
                 <FormControl
@@ -183,6 +215,7 @@ const Form: React.VFC<Props> = ({ internalUserId }) => {
                     !!errors.name ||
                     !!errors.email ||
                     !!errors.password ||
+                    !!errors.discordUserId ||
                     !isAdminData?.readIsAdmin.isAdmin
                   }
                 >

--- a/frontend/components/organisms/admin/internal_users/new/Form.tsx
+++ b/frontend/components/organisms/admin/internal_users/new/Form.tsx
@@ -6,6 +6,7 @@ import {
   FormControl,
   FormLabel,
   FormErrorMessage,
+  FormHelperText,
   Select,
 } from '@chakra-ui/react';
 import { useForm, Controller, SubmitHandler } from 'react-hook-form';
@@ -24,6 +25,7 @@ interface FormInput {
   name: string;
   email: string;
   password: string;
+  discordUserId: string;
   roleId: string;
 }
 
@@ -44,13 +46,20 @@ const Form: React.VFC<NoProps> = () => {
     name,
     email,
     password,
+    discordUserId,
     roleId,
   }) => {
     trigger();
 
     try {
       await create({
-        variables: { name, email, password, roleId: Number(roleId) },
+        variables: {
+          name,
+          email,
+          password,
+          roleId: Number(roleId),
+          discord_user_id: discordUserId,
+        },
       });
       setTimeout(() => {
         goAdminInternalUsers(router);
@@ -97,6 +106,33 @@ const Form: React.VFC<NoProps> = () => {
               />
               {errors.email && (
                 <FormErrorMessage>{errors.email.message}</FormErrorMessage>
+              )}
+            </FormControl>
+            <FormControl
+              id="discordUserId"
+              isRequired
+              isInvalid={!!errors.discordUserId}
+            >
+              <FormLabel>discord user id</FormLabel>
+              <Controller
+                name="discordUserId"
+                control={control}
+                rules={validators.discordUserId.rules}
+                render={({ field }) => (
+                  <Input
+                    type="text"
+                    isInvalid={!!errors.discordUserId}
+                    {...field}
+                  />
+                )}
+              />
+              <FormHelperText>
+                通知のメンションに必要です。18桁の数字が有効です
+              </FormHelperText>
+              {errors.discordUserId && (
+                <FormErrorMessage>
+                  {errors.discordUserId.message}
+                </FormErrorMessage>
               )}
             </FormControl>
             <FormControl id="password" isRequired isInvalid={!!errors.password}>
@@ -150,7 +186,12 @@ const Form: React.VFC<NoProps> = () => {
               mt="16"
               type="submit"
               isLoading={loading}
-              disabled={!!errors.name || !!errors.email || !!errors.password}
+              disabled={
+                !!errors.name ||
+                !!errors.email ||
+                !!errors.password ||
+                !!errors.discordUserId
+              }
             >
               新規登録する
             </PrimaryButton>

--- a/frontend/components/organisms/admin/products/detail/ProductCartItem.tsx
+++ b/frontend/components/organisms/admin/products/detail/ProductCartItem.tsx
@@ -71,10 +71,14 @@ const ProductCartItem: React.VFC<Props> = ({ productId }) => {
               mb="2"
               isFullWidth
               onClick={handleAddProductCartItem}
+              disabled={data.product.remainingStockAmount === 0}
             >
               <AddIcon mr="1" />
               在庫リクエストに入れる
             </SecondaryButton>
+            <Text fontSize="xs" color="text.secondary">
+              ※残数がない場合リクエストできません
+            </Text>
           </Box>
         </>
       ) : null}

--- a/frontend/validators/discordUserId.ts
+++ b/frontend/validators/discordUserId.ts
@@ -1,0 +1,11 @@
+export const rules = {
+  required: 'discord user idを入力してください',
+  minLength: {
+    value: 18,
+    message: '18文字で入力してください',
+  },
+  maxLength: {
+    value: 18,
+    message: '18文字で入力してください',
+  },
+};

--- a/frontend/validators/index.ts
+++ b/frontend/validators/index.ts
@@ -3,6 +3,7 @@ import * as password from './password';
 import * as username from './username';
 import * as maker from './maker';
 import * as productName from './productName';
+import * as discordUserId from './discordUserId';
 
 export default {
   email,
@@ -10,4 +11,5 @@ export default {
   username,
   maker,
   productName,
+  discordUserId,
 };

--- a/graphql/internalApi/schema.graphql
+++ b/graphql/internalApi/schema.graphql
@@ -172,6 +172,7 @@ input HospitalReservationStatusInputType {
 
 """A internal user"""
 type InternalUser {
+  discord_user_id: String!
   email: String!
   id: BigInt!
   name: String!
@@ -188,7 +189,7 @@ type Mutation {
   allocateStock(id: Int!, internalUserId: BigInt!): Stock!
   approveStockRequest(id: Int!, message: String!): Delete!
   createHospital(deleted: Boolean!, internal_memo: String!, name: String!, url: String): Hospital!
-  createInternalUser(email: String!, name: String!, password: String!, roleId: Int!): InternalUser!
+  createInternalUser(discord_user_id: String!, email: String!, name: String!, password: String!, roleId: Int!): InternalUser!
   createMaker(name: String!): Maker!
   createProduct(file: Upload!, makerId: Int!, name: String!, productTagIds: [Int!]!, remark: String!): Product!
   createProductTagGroup(name: String!): ProductTagGroup!
@@ -205,7 +206,7 @@ type Mutation {
   rejectStockRequest(id: Int!, message: String!): Delete!
   returnStock(id: Int!): Stock!
   updateHospital(deleted: Boolean!, hospitalAddressInput: HospitalAddressInputType!, hospitalBusinessFormInput: HospitalBusinessFormInputType!, hospitalCertificationOptionInput: HospitalCertificationOptionInputType!, hospitalInternalReputationInput: HospitalInternalReputationInputType!, hospitalNightServiceOptionInput: HospitalNightServiceOptionInputType!, hospitalNightUrgentActionOptionInput: HospitalNightUrgentActionOptionInputType!, hospitalReservationStatusInput: HospitalReservationStatusInputType!, id: BigInt!, internal_memo: String!, name: String!, url: String!): Hospital!
-  updateInternalUser(email: String!, id: BigInt!, name: String!, password: String!, roleId: Int!): InternalUser!
+  updateInternalUser(discord_user_id: String!, email: String!, id: BigInt!, name: String!, password: String!, roleId: Int!): InternalUser!
   updateMaker(id: Int!, name: String!): Maker!
   updateProduct(file: Upload, id: Int!, makerId: Int!, name: String!, remark: String!): Product!
   updateProductTag(id: Int!, name: String!): ProductTag!


### PR DESCRIPTION
* discord_user_id を用いてユーザの新規作成・更新を可能とした
* 在庫リクエストの承認と棄却で、承認者と棄却者も通知に追加
* 在庫がゼロの場合に、カートに追加不可能とした
* メンションするように変更