### PR TITLE
商品管理のカート機能のバグを修正

### DIFF
--- a/frontend/components/molecules/SummaryLink.tsx
+++ b/frontend/components/molecules/SummaryLink.tsx
@@ -5,14 +5,23 @@ import type { FC, PropsWithChildren } from 'react';
 
 type Props = {
   url: string;
+  openNewWindow?: boolean;
 };
 
-const SummaryLink: FC<PropsWithChildren<Props>> = ({ url, children }) => (
+const SummaryLink: FC<PropsWithChildren<Props>> = ({
+  url,
+  openNewWindow = true,
+  children,
+}) => (
   <SummaryRow>
     <Link href={url}>
-      <a target="_blank" rel="noreferrer">
-        {children}
-      </a>
+      {openNewWindow ? (
+        <a target="_blank" rel="noreferrer">
+          {children}
+        </a>
+      ) : (
+        <a>{children}</a>
+      )}
     </Link>
   </SummaryRow>
 );

--- a/frontend/components/organisms/admin/products/index/ProductStacks.tsx
+++ b/frontend/components/organisms/admin/products/index/ProductStacks.tsx
@@ -267,7 +267,10 @@ const ProductStacks: FC<NoProps> = () => {
           <Divider />
           {nodes?.map((product) => (
             <Fragment key={product.id}>
-              <SummaryLink url={ADMIN_PRODUCTS_DETAIL_PATH(product.id)}>
+              <SummaryLink
+                url={ADMIN_PRODUCTS_DETAIL_PATH(product.id)}
+                openNewWindow={false}
+              >
                 <ProductSummary product={product} />
               </SummaryLink>
               <Divider />

--- a/frontend/components/organisms/admin/stock_requests/index/stockRequestsStack/StockRequestSummary.tsx
+++ b/frontend/components/organisms/admin/stock_requests/index/stockRequestsStack/StockRequestSummary.tsx
@@ -18,7 +18,10 @@ const StockRequestSummary: FC<Props> = ({
   stockRequest,
   handleDeleteModalOpen,
 }) => (
-  <SummaryLink url={ADMIN_STOCK_REQUESTS_EDIT_PATH(stockRequest.id)}>
+  <SummaryLink
+    openNewWindow={false}
+    url={ADMIN_STOCK_REQUESTS_EDIT_PATH(stockRequest.id)}
+  >
     <Box
       display="flex"
       justifyContent="space-between"


### PR DESCRIPTION
## 目的

* 商品一覧から別ウィンドウで商品を開くようにしていたため、カートで利用していた local storage が動いていなかった
* そこで、一旦同一ウィンドウに戻して修正する

## 変更概要
