### PR TITLE
在庫リクエスト前の注意事項に送料の具体例を追加

### DIFF
--- a/frontend/components/organisms/admin/stock_requests/shared/Note.tsx
+++ b/frontend/components/organisms/admin/stock_requests/shared/Note.tsx
@@ -17,7 +17,7 @@ const Note: FC<NoProps> = () => (
         </ListItem>
         <ListItem>
           <ListIcon as={CheckCircleIcon} />
-          1回のリクエスト内容が送料を上回るようにしてください
+          1回のリクエスト内容が送料を上回るようにしてください.送料は安くても1100円〜1400円くらいかかります
         </ListItem>
       </List>
     </Box>


### PR DESCRIPTION
## 目的

* 備品を送ってもらう際、送料以上の備品をまとめて送らないと意味がない
* しかし、肝心の送料がいくらか分からずどのくらいまとめれば良いのかわからなかったので、具体的な送料を追加した

## 変更概要
