### PR TITLE
商品のサマリーに在庫責任者も表示

### DIFF
--- a/frontend/components/organisms/admin/products/ProductSummary.tsx
+++ b/frontend/components/organisms/admin/products/ProductSummary.tsx
@@ -38,6 +38,12 @@ const ProductSummary: FC<Props> = ({ product }) => (
           </SecondaryTag>
         ))}
         <Text fontSize="xs" mb="2">
+          責任者：
+          {Array.from(
+            new Set(product.stocks.map((s) => s.internalUser.name))
+          ).join(', ')}
+        </Text>
+        <Text fontSize="xs" mb="2">
           割当：
           {Array.from(
             new Set(


### PR DESCRIPTION
## 目的

* 商品を選ぶ際に同じ責任者から選びたい。それを円滑に行うために、責任者を商品一覧に表示する

## 変更概要
