### PR TITLE
商品管理の検索条件がページを跨いでも保持できるようにする

### DIFF
--- a/frontend/api/local_api/types.ts
+++ b/frontend/api/local_api/types.ts
@@ -39,10 +39,21 @@ export type ProductCartItem = {
   productId: Scalars['Int'];
 };
 
+export type ProductSearch = {
+  __typename?: 'ProductSearch';
+  allocatedInternalUserId?: Maybe<Scalars['Int']>;
+  hasStock?: Maybe<Scalars['Boolean']>;
+  internalUserId?: Maybe<Scalars['Int']>;
+  makerId?: Maybe<Scalars['Int']>;
+  name: Scalars['String'];
+  productTagId?: Maybe<Scalars['Int']>;
+};
+
 export type Query = {
   __typename?: 'Query';
   hospitalSearch: HospitalSearch;
   productCartItems: Array<ProductCartItem>;
+  productSearch: ProductSearch;
   readIsAdmin: ReadIsAdmin;
 };
 

--- a/frontend/utils/apollo/cache.ts
+++ b/frontend/utils/apollo/cache.ts
@@ -5,7 +5,7 @@ import type {
   Session,
   RoleFieldsFragment,
 } from '@/api/internal_api/types';
-import type { HospitalSearch } from '@/api/local_api/types';
+import type { HospitalSearch, ProductSearch } from '@/api/local_api/types';
 
 const productCartItemsVar = makeVar<
   CreateStockRequestRequestProductsInputType[]
@@ -20,6 +20,15 @@ const hospitalSearchVar = makeVar<HospitalSearch>({
   jsavaOption: false,
   nichijuOption: false,
   recommended: false,
+});
+
+const productSearchVar = makeVar<ProductSearch>({
+  name: '',
+  makerId: undefined,
+  productTagId: undefined,
+  internalUserId: undefined,
+  allocatedInternalUserId: undefined,
+  hasStock: true,
 });
 
 const getCache = () =>
@@ -62,9 +71,14 @@ const getCache = () =>
               return hospitalSearchVar();
             },
           },
+          productSearch: {
+            read() {
+              return productSearchVar();
+            },
+          },
         },
       },
     },
   });
 
-export { getCache, productCartItemsVar, hospitalSearchVar };
+export { getCache, productCartItemsVar, hospitalSearchVar, productSearchVar };

--- a/frontend/utils/apollo/schema.graphql
+++ b/frontend/utils/apollo/schema.graphql
@@ -23,8 +23,18 @@ type HospitalSearch {
   recommended: Boolean!
 }
 
+type ProductSearch {
+  name: String!
+  makerId: Int
+  productTagId: Int
+  internalUserId: Int
+  allocatedInternalUserId: Int
+  hasStock: Boolean
+}
+
 extend type Query {
   productCartItems: [ProductCartItem!]!
   readIsAdmin: ReadIsAdmin!
   hospitalSearch: HospitalSearch!
+  productSearch: ProductSearch!
 }


### PR DESCRIPTION
## 目的

* 商品を在庫に入れる度に検索結果がクリアされてしまい使いづらいので、ページを跨いでも検索結果が保持されるように変更する

## 変更概要
