### PR TITLE
discord id のバリデーションを 18~19 字に変更

### DIFF
--- a/frontend/validators/discordUserId.ts
+++ b/frontend/validators/discordUserId.ts
@@ -2,10 +2,10 @@ export const rules = {
   required: 'discord user idを入力してください',
   minLength: {
     value: 18,
-    message: '18文字で入力してください',
+    message: '18文字以上で入力してください',
   },
   maxLength: {
-    value: 18,
-    message: '18文字で入力してください',
+    value: 19,
+    message: '19文字以内で入力してください',
   },
 };


### PR DESCRIPTION
## 目的

## 変更概要
