### PR TITLE
discord user id の有効な値の説明文を 18~19 桁に変更

### DIFF
--- a/frontend/components/organisms/admin/internal_users/new/Form.tsx
+++ b/frontend/components/organisms/admin/internal_users/new/Form.tsx
@@ -130,7 +130,7 @@ const Form: FC<NoProps> = () => {
                 )}
               />
               <FormHelperText>
-                通知のメンションに必要です。18桁の数字が有効です
+                通知のメンションに必要です。18~19桁の数字が有効です
               </FormHelperText>
               {errors.discordUserId && (
                 <FormErrorMessage>


### PR DESCRIPTION
## 目的

## 変更概要
