### PR TITLE
discord user id の説明文を 18~19 桁に変更（ユーザ編集画面）

### DIFF
--- a/frontend/components/organisms/admin/internal_users/edit/Form.tsx
+++ b/frontend/components/organisms/admin/internal_users/edit/Form.tsx
@@ -151,7 +151,7 @@ const Form: FC<Props> = ({ internalUserId }) => {
                     )}
                   />
                   <FormHelperText>
-                    通知のメンションに必要です。18桁の数字が有効です
+                    通知のメンションに必要です。18~19桁の数字が有効です
                   </FormHelperText>
                   {errors.discordUserId && (
                     <FormErrorMessage>


### PR DESCRIPTION
## 目的

## 変更概要
