### PR TITLE
備品検索時に英字の大文字と小文字を区別しないようにする

### DIFF
--- a/backend/server/graphql/internalApi/queries/productConnection.ts
+++ b/backend/server/graphql/internalApi/queries/productConnection.ts
@@ -20,7 +20,10 @@ export const productConnection = queryField((t) => {
     resolve: async (_root, args, ctx) => {
       const products = await ctx.prisma.product.findMany({
         where: {
-          name: { contains: args.name ? args.name : undefined },
+          name: {
+            contains: args.name ? args.name : undefined,
+            mode: 'insensitive',
+          },
           maker_id: args.makerId ? args.makerId : undefined,
           productTaggings: args.productTagId
             ? {


### PR DESCRIPTION
## 目的

## 変更概要
